### PR TITLE
admin: removing credential to obtain 404 error

### DIFF
--- a/tasks/admin.yml
+++ b/tasks/admin.yml
@@ -10,9 +10,6 @@
     url: '{{ gitea_app_cont_web_url }}/api/v1/users/{{ gitea_app_admin_user }}'
     status_code: [200, 404]
     return_content: true
-    user: '{{ gitea_app_admin_user | mandatory }}'
-    password: '{{ gitea_app_admin_pass | mandatory }}'
-    force_basic_auth: true
   register: gitea_admin_user_raw
 
 - name: Create main Gitea admin user

--- a/tasks/admin.yml
+++ b/tasks/admin.yml
@@ -14,8 +14,8 @@
 
 - name: Create main Gitea admin user
   command: |
-    docker exec -i {{ gitea_app_cont_name }} \
-      gitea admin create-user --admin \
+    docker exec --user {{ gitea_app_cont_uid }} -i {{ gitea_app_cont_name }} \
+      gitea admin user create --admin \
         --username '{{ gitea_app_admin_user | mandatory }}' \
         --password '{{ gitea_app_admin_pass | mandatory }}' \
         --email '{{ gitea_app_admin_email | mandatory }}' \

--- a/tasks/token.yml
+++ b/tasks/token.yml
@@ -18,14 +18,12 @@
         user: '{{ gitea_app_admin_user | mandatory }}'
         password: '{{ gitea_app_admin_pass | mandatory }}'
         force_basic_auth: true
-      register: gitea_app_admin_token_raw
 
     - name: Create an API token file
       copy:
         dest: '{{ gitea_service_path }}/api-token'
         content: '{{ gitea_app_admin_token_raw.json.sha1 }}'
         mode: 0400
-      when: not gitea_app_admin_token_raw.skipped
 
 - name: Read API token from file
   slurp:

--- a/templates/gitea.ini.j2
+++ b/templates/gitea.ini.j2
@@ -75,3 +75,6 @@ REQUIRE_SIGNIN_VIEW  = false
 
 [oauth2]
 JWT_SECRET = {{ gitea_app_jwt_secret | mandatory }}
+
+[packages]
+ENABLED=true

--- a/templates/gitea.ini.j2
+++ b/templates/gitea.ini.j2
@@ -20,8 +20,10 @@ ROOT_URL         = https://{{ gitea_app_web_domain | mandatory }}
 DISABLE_SSH      = false
 SSH_PORT         = {{ gitea_app_ssh_port }}
 LFS_START_SERVER = false
-LFS_CONTENT_PATH = /data/git/lfs
 LANDING_PAGE     = explore
+
+[lfs]
+PATH = /data/git/lfs
 
 [database]
 DB_TYPE = postgres


### PR DESCRIPTION
Auth not mandatory on the endpoint `/users/user-id`.

Combination of status code by possibilty:

|  Credential   |     User     | Status code |
|:-------------:|:------------:|:-----------:|
|    Correct    |   Existing   |     200     |
|       -       | Not existing |     401     |
|   Incorrect   |   existing   |     401     |
| No credential |   Existing   |     200     |
| No Credential | Not existing |     404     |

To avoid recreating a user if the credentials have change, it's better to expected a 404 code and not set authentification in the call