### PR TITLE
config: disable repo_archives

### DIFF
--- a/templates/gitea.ini.j2
+++ b/templates/gitea.ini.j2
@@ -78,3 +78,8 @@ JWT_SECRET = {{ gitea_app_jwt_secret | mandatory }}
 
 [packages]
 ENABLED=true
+
+[cron.delete_repo_archives]
+ENABLED = true
+RUN_AT_START = true
+SCHEDULE = @midnight;


### PR DESCRIPTION
We use gitea as a github archive and we also backup repos in restic.